### PR TITLE
chore!: update dependencies and require node >=22.22

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,21 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+    inputs:
+      force-release:
+        description: 'Force release to npm'
+        required: false
+        type: boolean
+
 permissions:
-  contents: write
+  contents: read
   id-token: write
-  packages: write
-  pull-requests: write
 
 jobs:
   release-please:
-    uses: voxpelli/ghatemplates/.github/workflows/release-please-4.yml@main
+    uses: voxpelli/ghatemplates/.github/workflows/release-please-oidc.yml@main
     secrets: inherit
+    with:
+      app-id: '1082006'
+      force-release: ${{ inputs.force-release || false }}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "@types/normalize-package-data": "^2.4.4",
     "normalize-package-data": "^6.0.1",
     "peowly": "^2.0.0",
-    "read-package-up": "^11.0.0"
+    "read-package-up": "^12.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chalk": "^6.0.0",
     "eslint": "^9.10.0",
     "husky": "^9.1.7",
-    "installed-check": "^10.0.1",
+    "installed-check": "^11.0.0",
     "knip": "^6.31.0",
     "markdown-or-chalk": "^0.3.2",
     "npm-run-all2": "^9.0.3",
@@ -62,12 +62,12 @@
     "trim-newlines": "^5.0.0",
     "type-coverage": "^2.30.1",
     "typescript": "^6.0.3",
-    "validate-conventional-commit": "^1.0.4"
+    "validate-conventional-commit": "^2.0.0"
   },
   "dependencies": {
     "@types/normalize-package-data": "^2.4.4",
     "normalize-package-data": "^8.0.0",
-    "peowly": "^2.0.0",
+    "peowly": "^2.0.1",
     "read-package-up": "^12.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Pelle Wessman <pelle@kodfabrik.se> (http://kodfabrik.se/)",
   "license": "MIT",
   "engines": {
-    "node": "^22.13.0 || >=24.0.0",
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
     "typescript": ">=6"
   },
   "type": "module",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@types/normalize-package-data": "^2.4.4",
-    "normalize-package-data": "^6.0.1",
+    "normalize-package-data": "^8.0.0",
     "peowly": "^2.0.0",
     "read-package-up": "^12.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "knip": "^6.31.0",
     "markdown-or-chalk": "^0.3.2",
     "npm-run-all2": "^9.0.3",
-    "ora": "^8.1.0",
+    "ora": "^9.4.1",
     "pony-cause": "^2.1.11",
     "redent": "^4.0.0",
     "trim-newlines": "^5.0.0",


### PR DESCRIPTION
Bump `read-package-up` to v12, `normalize-package-data` to v8, `ora` to v9, `installed-check` to v11, `validate-conventional-commit` to v2, and `peowly` to v2.0.1. Tighten Node engine requirements to `^22.22.2 || ^24.15.0 || >=26.0.0`.

Replace the release workflow with the OIDC-based trusted publishing template (`release-please-oidc.yml`), reducing permissions to `contents: read` and `id-token: write` and adding a `force-release` manual dispatch input.

BREAKING CHANGE: Raises minimum Node to `^22.22.2 || ^24.15.0 || >=26.0.0` to align with npm 12 and its core modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking change:** Requires Node.js `^22.22.2 || ^24.15.0 || >=26.0.0` to align with npm 12.
- Updates dependencies, including `read-package-up` v12, `normalize-package-data` v8, `ora` v9, `installed-check` v11, `validate-conventional-commit` v2, and `peowly` v2.0.1.
- Migrates releases to the OIDC trusted publishing workflow with restricted permissions.
- Adds a manual `force-release` workflow input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->